### PR TITLE
Add Go development container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+    "name": "Maxfacts Go Development",
+    "image": "mcr.microsoft.com/devcontainers/go:1-1.23-bookworm",
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "go.toolsManagement.checkForUpdates": "local",
+                "go.useLanguageServer": true,
+                "go.gopath": "/go"
+            },
+            "extensions": [
+                "golang.Go",
+                "streetsidesoftware.code-spell-checker"
+            ]
+        }
+    },
+    "forwardPorts": [3000],
+    "postCreateCommand": "go mod download",
+    "remoteUser": "vscode"
+}


### PR DESCRIPTION
## Summary
- Add minimal devcontainer setup for Go development environment  
- Enable consistent development experience without local Go installation

## Changes
- Create `.devcontainer/devcontainer.json` with Go 1.23 configuration
- Include essential VS Code extensions (Go language support, spell checker)
- Configure automatic port forwarding for the application (port 3000)
- Set up automatic Go module download on container creation

## Test plan
- [ ] Install VS Code Dev Containers extension
- [ ] Open project and select "Reopen in Container" from command palette
- [ ] Verify Go development tools work correctly in container
- [ ] Confirm application runs on forwarded port 3000

🤖 Generated with [Claude Code](https://claude.ai/code)