### PR TITLE
Add Go development container with Claude Code support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+    "name": "Maxfacts Go Development with Claude Code",
+    "image": "mcr.microsoft.com/devcontainers/go:1-1.24-bookworm",
+    "features": {
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "20"
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "go.toolsManagement.checkForUpdates": "local",
+                "go.useLanguageServer": true,
+                "go.gopath": "/go"
+            },
+            "extensions": [
+                "golang.Go",
+                "streetsidesoftware.code-spell-checker",
+                "anthropic.claude-code"
+            ]
+        }
+    },
+    "forwardPorts": [3000],
+    "postCreateCommand": "go mod download && npm install -g @anthropic-ai/claude-code",
+    "remoteUser": "vscode",
+    "mounts": [
+        "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached"
+    ],
+    "containerEnv": {
+        "CLAUDE_CODE_IN_DEVCONTAINER": "true"
+    }
+}


### PR DESCRIPTION
## Summary
- Add devcontainer configuration for Go 1.24 development
- Enable Claude Code CLI within the development container
- Support both Go development and AI assistance in isolated environment

## Changes
- Create `.devcontainer/devcontainer.json` with dual Go + Claude Code configuration
- Use Microsoft's Go 1.24 devcontainer image as base
- Add Node.js 20 feature for Claude Code runtime
- Install `@anthropic-ai/claude-code` package globally
- Mount local Claude configuration directory for credential persistence
- Include Claude Code VS Code extension for full IDE integration

## Test plan
- [ ] Rebuild container in VS Code using "Reopen in Container"
- [ ] Verify Go 1.24 is available with `go version`
- [ ] Verify Claude Code CLI works with `claude --version`
- [ ] Test Go development features (build, run, debug)
- [ ] Test Claude Code features within the container context
- [ ] Verify credentials persist between container rebuilds

🤖 Generated with [Claude Code](https://claude.ai/code)